### PR TITLE
Update README.md with install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Este repositorio contiene un clon del popular servicio de música Spotify constr
 ## Instalación
 
 1. Clona este repositorio:
-   `git clone https://github.com/midudev/spotify-astro-clone.git`
+   `git clone https://github.com/midudev/spotify-twitch-clone.git`
 
 2. Navega a la carpeta del proyecto:
-   `cd spotify-astro-clone`
+   `cd spotify-twitch-clone`
 
 3. Instala las dependencias:
    `bun install`


### PR DESCRIPTION
The name of the Git repo was not correct on the installation/clone steps to follow.