### PR TITLE
Update [id].astro (hours or minutes from the playlist)

### DIFF
--- a/src/pages/playlist/[id].astro
+++ b/src/pages/playlist/[id].astro
@@ -8,6 +8,38 @@ const { id } = Astro.params
 
 const playlist = allPlaylists.find((playlist) => playlist.id === id)
 const playListSongs = songs.filter((song) => song.albumId === playlist?.albumId)
+
+const durationInSeconds = (duration: string): number => {
+  const parts = duration.split(":").map(Number);
+  if (parts.length === 2) {
+    // Si la duración solo tiene minutos y segundos
+    return parts[0] * 60 + parts[1]; // Convertir a segundos
+  } else if (parts.length === 3) {
+    // Si la duración incluye horas, minutos y segundos
+    return parts[0] * 3600 + parts[1] * 60 + parts[2]; // Convertir a segundos
+  } else {
+    return 0; // Duración inválida
+  }
+};
+
+const formatDuration = (totalSeconds: number): string => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours} h`;
+  } else {
+    return `${minutes} min`;
+  }
+};
+
+// Calcular la duración total en segundos y formatearla
+const totalDurationInSeconds = playListSongs.reduce(
+  (acc, song) => acc + durationInSeconds(song.duration),
+  0
+);
+
+const formattedDuration = formatDuration(totalDurationInSeconds);
 ---
 
 <Layout title="Spotify Clone">
@@ -44,7 +76,7 @@ const playListSongs = songs.filter((song) => song.albumId === playlist?.albumId)
             </div>
             <p class="mt-1">
               <span class="text-white">{playListSongs.length} canciones</span>,
-              3 h aproximadamente
+              {formattedDuration} aproximadamente
             </p>
           </div>
         </div>


### PR DESCRIPTION
Este pull request actualiza el archivo [id].astro para mostrar la duración total de la lista de reproducción en horas o minutos, según corresponda. La duración se calcula dinámicamente a partir de la lista de reproducción.

**[Despues]**
![image](https://github.com/midudev/spotify-twitch-clone/assets/86846618/c4b9ddef-b4ed-4110-959e-ea306c195e7b)

[Antes]
![image](https://github.com/midudev/spotify-twitch-clone/assets/86846618/c580279c-c024-4376-bac9-3af89f6e54c4)
